### PR TITLE
FIX🐛: Improve useCallback and useEffect to suppress an infinity loop

### DIFF
--- a/frontend/src/views/pages/FriendsHistoryPage.tsx
+++ b/frontend/src/views/pages/FriendsHistoryPage.tsx
@@ -38,6 +38,7 @@ export const FriendsHistoryPage = () => {
   const materialTheme = useTheme();
   const isMobile = useMediaQuery(materialTheme.breakpoints.down("sm"));
   const [error, setError] = useState("");
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [categories, setCategories] = useState<Category[]>([]);
 
   const handleDrawerToggle = () => {


### PR DESCRIPTION
## Describe details
- After improving to reduce build warnings, we removed a dependency array of `useEffect`
- However, this causes an infinity loop to fetch API.
- In this PR, we improve this infinity loop problem.

## Changes
- Implemented `useCallback` to `getCategories`
- Changed the place to define a supabase client varialbe
- 